### PR TITLE
fix warning by specifying explicit plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
         <artifactId>codeql2sonar-maven-plugin</artifactId>
         <version>${project.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>5.0.0.4389</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Warning:  Using an unspecified version instead of an explicit plugin version may introduce breaking analysis changes at an unwanted time. It is highly recommended to use an explicit version, e.g. 'org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389'.